### PR TITLE
ci(docs): configure the GH Actions workflow to build and deploy the docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,39 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build the Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Install & Build the Docs
+        uses: withastro/action@v4.0.0
+        with:
+          path: docs
+          package-manager: pnpm
+
+  deploy:
+    name: Deploy the Docs
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
This PR includes a new GitHub Actions workflow to automate the building and deployment procedure of the project documentations.

The workflow utilises some Actions (officially provided by the Astro devs) to build and generate the documentations. After the static assets are generated and built, the documentations is then deployed to GitHub Pages (using another officially provided GitHub Actions from the GitHub devs).