### PR TITLE
chore(docs): add a user guide section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[*.{mts}]
+[*.{mts,mjs}]
 indent_style = space
 indent_size = 2

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -23,7 +23,18 @@ export default defineConfig({
       },
       lastUpdated: true,
       sidebar: [
-        { label: "Developer Guide", autogenerate: { directory: "dev-guide" } },
+        {
+          label: "Welcome",
+          autogenerate: {
+            directory: "usage-guide",
+          },
+        },
+        {
+          label: "Developer Guide",
+          autogenerate: {
+            directory: "dev-guide",
+          },
+        },
       ],
     }),
   ],

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
   #   file: ../../assets/houston.webp
   actions:
     - text: Usage Guide
-      link: /usage-guide
+      link: /crisp/usage-guide
       icon: right-arrow
 next: false
 editUrl: false

--- a/docs/src/content/docs/usage-guide/index.md
+++ b/docs/src/content/docs/usage-guide/index.md
@@ -1,0 +1,161 @@
+---
+title: Getting Started
+description: Get started with using Crisp to lint your commit messages.
+---
+
+Getting started with using Crisp is very straight-forward and not very involved
+in any way! To get started with using Crisp for your requirements, you have the
+following options:
+
+1. Use as a [Pre-Commit](https://pre-commit.com) hook (**RECOMMENDED**).
+2. Use as a standlone tool, either built from source or downloaded using a
+   package manager ([Homebrew](https://brew.sh), APT and so on) (**docs are
+   WIP**, hence contributions are welcome).
+3. Use in a CI environment (**docs are WIP**, hence contributions are welcome).
+
+The following sections of the documentations will walk you through the various
+ways to get started with using Crisp.
+
+## Pre-Commit Hook
+
+The easiest and most straight-forward approach for using Crisp is to utilise it
+as a Pre-Commit hook. So, the following steps will help you with the process:
+
+1. Ensure Pre-Commit is locally installed and accessible (following the
+   [official installation guidelines](https://pre-commit.com#installation)).
+
+2. Create a `.pre-commit-config.yaml` file with the following contents:
+
+   ```yaml
+   repos:
+     - repo: https://github.com/Weburz/crisp
+       rev: "v0.1.5"
+       hooks:
+         - id: crisp
+   ```
+
+3. Setup the hooks for your project by executing:
+
+   ```console
+   pre-commit install --install-hooks
+   ```
+
+4. To test out whether Crisp is working as part of your Pre-Commit hooks, try
+   adding a dummy commit like so:
+
+   ```console
+   touch .gitkeep
+   git add .gitkeep
+   git commit -m 'chore: added a dummy .gitkeep file'
+   ```
+
+If Crisp was setup properly, you will see either a passing/failing message on
+STDOUT. If the output is a failing message then your commit message obviously
+does not follow the
+[Conventional Commits specifications](https://conventionalcommits.org) and you
+will have to improve it accordingly.
+
+## Install Using a Package Manager
+
+Crisp can also be used as a standalone tool, installed using your OS's package
+manager of choice. Hence, this section of the docs will walk you through the
+process of getting started with its usage accordingly.
+
+Crisp is available on all major platforms including some of the major Linux
+distributions, MacOS and Windows. To get Crisp through your preferred choice of
+package manager on the platform you are using, follow the relevant instructions
+provided below:
+
+### Homebrew (TBA)
+
+### Winget (TBA)
+
+### Debian/Ubuntu (TBA)
+
+### AUR (TBA)
+
+### Fedora, RHEL, Centos (TBA)
+
+Post installation, run the following command to test whether Crisp was installed
+appropriately and is usable;
+
+```console
+crisp version
+```
+
+The command above should print useful build information relevant to the platform
+you are using Crisp on which can also prove valuable during debugging sessions
+if you are facing issues with it.
+
+## Build From Source
+
+Crisp can also be built from source and used accordingly. The added benefit of
+this approach is you will get to the test out the absolute latest
+functionalities of the tool before they are stabilised and shipped. Follow these
+steps if you are interested in building Crisp from source code:
+
+1. Clone the source code's remote repository from our GitHub organisation by
+   invoking:
+
+   ```console
+   git clone --depth 1 git@github.com:Weburz/crisp
+   ```
+
+2. Ensure you have [Go](https://go.dev) and [Task](https://taskfile.dev)
+   installed. Check it by invoking the following commands:
+
+   ```console
+   go version
+   ```
+
+   ```console
+   task --version
+   ```
+
+3. When you are ready with the build tools, invoke the following build command;
+
+   ```console
+   task build
+   ```
+
+   The command will build the executable binary in the `bin` directory.
+
+4. Copy the built executable binary to the `~/.local/bin` directory (on
+   Linux/MacOS) or `C:\Program Files\Crisp` (on Windows).
+
+   **Linux/MacOS**:
+
+   ```console
+   mv ./bin/crisp ~/.local/bin/crisp
+   ```
+
+   **Windows**:
+
+   ```powershell
+   Copy-Item ".\bin\crisp" -Destination "C:\Program Files\Crisp"
+   ```
+
+5. With the executable binary copied to an appropriate location, you should now
+   update the `$PATH` variable of your system so that the `crisp` command can be
+   invoked from anywhere on your filesystem.
+
+   **Linux/MacOS**:
+
+   To update the `$PATH`, you will have to add the following lines to the
+   `.bashrc`/`.zshrc` file (only on Linux and MacOS systems):
+
+   ```sh
+   export PATH="$PATH:$HOME/.local/bin"
+   ```
+
+   **Windows**:
+
+   Run the following command in a PowerShell session;
+
+   ```powershell
+   $ENV:PATH += ";C:\Program Files\Crisp"
+   ```
+
+## Usage in CI Environments
+
+TODO: Add docs on using Crisp to lint PR titles and more

--- a/docs/src/content/docs/usage-guide/reference.md
+++ b/docs/src/content/docs/usage-guide/reference.md
@@ -1,0 +1,76 @@
+---
+title: Command-Line Interface (CLI) Reference
+description: The CLI reference of Crisp
+---
+
+Crisp as a CLI tool is rather quite simple and straight-forward to use. It has
+been kept that way intentionally and its simplicity is one of the core design
+principle of the tool. Hence this section of the documentation provides a
+detailed reference of the very list of commands available for `crisp`.
+
+While this section of the documentation exists for an easier reference browsing
+over your preferred web browser, it is highly recommended you use `help` command
+for quick reference instead.
+
+## Reference
+
+| Command      | Description                                                 |
+| ------------ | ----------------------------------------------------------- |
+| `completion` | Generate the autocompletion script for the specified shell. |
+| `help`       | Help about any command for `crisp`.                         |
+| `message`    | Lint a Git commit message using `crisp`.                    |
+| `version`    | Print the version and build information of `crisp`.         |
+
+### `completion`
+
+The `crisp completion` subcommand provides the following arguments and the
+purposes they fulfill.
+
+| Subcommand   | Description                                        |
+| ------------ | -------------------------------------------------- |
+| `bash`       | Generate the autocompletion script for Bash.       |
+| `fish`       | Generate the autocompletion script Fish.           |
+| `powershell` | Generate the autocompletion script for PowerShell. |
+| `zsh`        | Generate the autocompletion script Zsh.            |
+
+TODO: Add some examples of its usage.
+
+### `help`
+
+Print a helpful usage message of a command/subcommand.
+
+**Examples**:
+
+```console
+crisp help version
+```
+
+```console
+crisp help message
+```
+
+### `message`
+
+Lint a Git commit message using this command in accordance to the
+[Conventional Commits v1.0.0 specification](https://conventionalcommits.org).
+
+**Examples**:
+
+```console
+crisp message "chore: fix an annoying bug"
+```
+
+```console
+echo "feat: add an amazing feature" | crisp message --stdin
+```
+
+### `version`
+
+Print valuable build and version information of Crisp to `STDOUT` useful for
+debugging purposes mostly.
+
+**Examples**:
+
+```console
+crisp version
+```


### PR DESCRIPTION
This PR updates the documentation and adds the following sections to it:

1. A user guide.
2. A CLI reference.

In addition to those, the PR also introduces some slight configuration changes for Astro to properly identify the location of the Markdown files to process during the build process.