### PR TITLE
chore(validator): refactor the `validator` package

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -69,7 +69,7 @@ var messageCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if status, err := validator.ValidateMessage((*parser.Message)(m)); err != nil {
+		if status, err := validator.ValidateMessage(m); err != nil {
 			cmd.PrintErrf("error: %s\n", err)
 			os.Exit(1)
 		} else {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -4,7 +4,6 @@ package parser
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -73,53 +72,4 @@ func (p *parserImpl) Parse(message string) (*CommitMessage, error) {
 	}
 
 	return parsed, nil
-}
-
-/**
- * Message - A struct to represent a git-commit Message.
- *
- * Fields:
- *   Type:        A string representing the type of the Message.
- *   Scope:       A string indicating the scope or category of the Message.
- *   Description: A brief description or title of the Message.
- *   Body:        The main content or body of the Message.
- *   Footer:      Additional information or footer text to accompany the Message.
- *
- * NOTE: This struct is deprecated and will be removed in the near future.
- */
-type Message struct {
-	Type        string // Type of the message (e.g., "info", "error")
-	Scope       string // Scope of the message (e.g., "global", "user")
-	Description string // A brief description or title of the message
-	Body        string // The main content or body of the message
-	Footer      string // Additional footer information
-}
-
-/**
- * ParseMessage: Accept a string and parser it into a struct for validation.
- *
- * Parameters:
- *   message (string): The Git commit message to parser.
- *
- * Returns:
- *   None
- *
- * NOTE: This function is deprecated and will be removed in the near future.
- */
-func ParseMessage(input string) (Message, error) {
-	re := regexp.MustCompile(
-		`^(?P<Type>\w+)(?:\((?P<Scope>\w+)\))?: \s*(?P<Description>.+)$`,
-	)
-
-	matches := re.FindStringSubmatch(input)
-
-	if matches == nil {
-		return Message{}, fmt.Errorf("invalid commit message format")
-	}
-
-	return Message{
-		Type:        matches[1],
-		Scope:       matches[2],
-		Description: matches[3],
-	}, nil
 }

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1,0 +1,141 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/Weburz/crisp/internal/parser"
+)
+
+func TestIsValidType(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		input       string
+		expectError bool
+	}{
+		{"feat", false},
+		{"FIX", true},
+		{"unknown", true},
+		{"docs", false},
+		{"ReFacTor", true},
+	}
+
+	for _, tt := range tests {
+		err := v.isValidType(tt.input)
+		if tt.expectError && err == nil {
+			t.Errorf("expected error for input %q, but got nil", tt.input)
+		}
+		if !tt.expectError && err != nil {
+			t.Errorf("did not expect error for input %q, but got: %v", tt.input, err)
+		}
+	}
+}
+
+func TestIsValidScope(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		scope       string
+		expectError bool
+	}{
+		{"", false},
+		{"parser", false},
+		{"Parser", true},
+		{"Auth", true},
+	}
+
+	for _, tt := range tests {
+		err := v.isValidScope(tt.scope)
+		if tt.expectError && err == nil {
+			t.Errorf("expected error for scope %q, but got nil", tt.scope)
+		}
+		if !tt.expectError && err != nil {
+			t.Errorf("did not expect error for scope %q, but got: %v", tt.scope, err)
+		}
+	}
+}
+
+func TestIsValidSubject(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		description string
+		expectError bool
+	}{
+		{"add new feature", false},
+		{"Add new feature", true},
+		{"fix user login.", true},
+		{"", true},
+	}
+
+	for _, tt := range tests {
+		err := v.isValidSubject(tt.description)
+		if tt.expectError && err == nil {
+			t.Errorf("expected error for description %q, but got nil", tt.description)
+		}
+		if !tt.expectError && err != nil {
+			t.Errorf(
+				"did not expect error for description %q, but got: %v",
+				tt.description,
+				err,
+			)
+		}
+	}
+}
+
+func TestValidateMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         *parser.CommitMessage
+		expectError bool
+	}{
+		{
+			name: "valid message",
+			msg: &parser.CommitMessage{
+				Type:        "feat",
+				Scope:       "parser",
+				Description: "add parsing support",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid type",
+			msg: &parser.CommitMessage{
+				Type:        "Feat",
+				Scope:       "parser",
+				Description: "add parsing support",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid scope",
+			msg: &parser.CommitMessage{
+				Type:        "fix",
+				Scope:       "Parser",
+				Description: "fix the bug",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid description",
+			msg: &parser.CommitMessage{
+				Type:        "fix",
+				Scope:       "auth",
+				Description: "Fix login issue.",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ValidateMessage(tt.msg)
+			if tt.expectError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR improves the `validator` package significantly with the following changes:

1. Remove the deprecated logic which were earlier integrating the parsing logic with the validator.
2. Refactored the APIs of the `validator` package for bettter legibility and code maintenance.