### PR TITLE
ci: add a workflow to mark and close stale issues/PRs

### DIFF
--- a/.github/workflows/mark-stale.yml
+++ b/.github/workflows/mark-stale.yml
@@ -1,0 +1,42 @@
+name: Mark Stale Issues/PRs
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  mark-stale:
+    name: Mark & Close Stale Issues/PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and Close Stale Issues/PRs
+        uses: actions/stale@v9.1.0
+        with:
+          stale-issue-message: |
+            This issue has not seen any recent activity over the past 45 days, hence
+            it will be labeled as stale and closed within a week. If that is unintended
+            then please remove the "stale" label and leave a relevant comment to keep
+            the thread open.
+          stale-pr-message: |
+            This Pull Request has not seen any recent activity over the past 30 days,
+            hence it will be marked as stale and closed in 10 days from now. If this is
+            unintended, then please remove the "stale" label and leave relevant comment
+            to keep PR open.
+          days-before-issue-stale: 45
+          days-before-pr-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-close: 10
+          close-issue-message: |
+            This issue has been closed since it has not seen any recent activity. If
+            this is unintended, then please reopen the issue or create a fresh new
+            thread.
+          close-pr-message: |
+            This Pull Request has been closed since it has not seen any recent
+            activity. If this is unintended, then please reopen the Pull Request or
+            create a fresh new one.
+          delete-branch: true


### PR DESCRIPTION
This PR includes a simple GH Actions workflow to mark and close stale issues and Pull Requests.