### PR TITLE
chore(version): refactor the `version` package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ var rootCmd = &cobra.Command{
 	Use:   "crisp",
 	Short: "A linter for Git commit messages.",
 	Long: `A linter to check whether your Git commit messages are according to
-the "commitlint" specifications.`,
+the Conventional Commits spec.`,
 }
 
 // Execute adds all child commands to the root command and sets flags

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"github.com/Weburz/crisp/internal/version"
-
 	"github.com/spf13/cobra"
 )
 
 var shortUsageHelp = "Print the version information."
+
 var longUsageHelp = `Prints a detailed version information of the application including
 version, commit hash, the build date and the version of Go used to develop it.`
 
@@ -15,15 +15,16 @@ var versionCmd = &cobra.Command{
 	Short: shortUsageHelp,
 	Long:  longUsageHelp,
 	Run: func(cmd *cobra.Command, args []string) {
-		version := version.Get()
+		v := version.GetVersionInfo()
+
 		cmd.Println("### Crisp Build Information ###")
-		cmd.Printf("Version: \t%s\n", version.Version)
-		cmd.Printf("Git Version: \t%s\n", version.GitVersion)
-		cmd.Printf("Git Commit: \t%s\n", version.GitCommit)
-		cmd.Printf("Build Date: \t%s\n", version.BuildDate)
-		cmd.Printf("Go Version: \t%s\n", version.GoVersion)
-		cmd.Printf("Compiler: \t%s\n", version.Compiler)
-		cmd.Printf("Platform: \t%s\n", version.Platform)
+		cmd.Printf("Version: \t%s\n", v.Version)
+		cmd.Printf("Git Version: \t%s\n", v.GitVersion)
+		cmd.Printf("Git Commit: \t%s\n", v.GitCommit)
+		cmd.Printf("Build Date: \t%s\n", v.BuildDate)
+		cmd.Printf("Go Version: \t%s\n", v.GoVersion)
+		cmd.Printf("Compiler: \t%s\n", v.Compiler)
+		cmd.Printf("Platform: \t%s\n", v.Platform)
 	},
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -22,18 +22,7 @@ var (
 	buildDate  = "unknown"
 )
 
-/**
- * VersionInfo - A struct to contain the version information of the software.
- *
- * Fields:
- *   GitVersion: (string) The version of Git used to build Terox.
- *   GitCommit: (string) The commit hash used to build Terox.
- *   BuildDate: (string) The datetime string when the Terox binary was built.
- *   GoVersion: (string) The Go version used to compile the Terox binary.
- *   Compiler: (string) The compiler used to build and compile the Terox binary.
- *   Platform: (string) The platform (OS & architecture) of the Terox binary.
- */
-type VersionInfo struct {
+type versionInfo struct {
 	Version    string
 	GitVersion string
 	GitCommit  string
@@ -43,23 +32,14 @@ type VersionInfo struct {
 	Platform   string
 }
 
-/**
- * Get: Fetch and return the various version information.
- *
- * Parameters:
- *   None
- *
- * Returns:
- *   Returns an instance of the VersionInfo struct.
- */
-func Get() *VersionInfo {
-	return &VersionInfo{
+func GetVersionInfo() *versionInfo {
+	return &versionInfo{
+		Version:    version,
 		GitVersion: gitVersion,
 		GitCommit:  gitCommit,
 		BuildDate:  buildDate,
 		GoVersion:  runtime.Version(),
 		Compiler:   runtime.Compiler,
-		Version:    version,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
 }


### PR DESCRIPTION
This PR introduces a bunch of refactors to improve the legibility and maintenance status of the `version` package.