### PR TITLE
feat: add logic to validate commit message length

### DIFF
--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -92,6 +92,30 @@ func (v *validator) isValidSubject(s string) error {
 	return nil
 }
 
+// isValidLength checks whether the length of the given commit message string does not
+// exceed the predefined character limit.
+//
+// It enforces a hard limit of 50 characters, as recommended by the Conventional Commits
+// specification for concise subject lines.
+//
+// Parameters:
+//   - s: The commit message string to validate.
+//
+// Returns:
+//   - An error if the message exceeds the 50-character limit.
+//   - nil if the message length is within the allowed limit.
+func (v *validator) isValidLength(s string) error {
+	charLimit := 50
+	if len(s) > charLimit {
+		return fmt.Errorf(
+			"commit message is %d long but expected length should be %d",
+			len(s),
+			charLimit,
+		)
+	}
+	return nil
+}
+
 // ValidateMessage() validates a Conventional Commit message.
 //
 // It checks the type, scope and subject of the committ message for validation errors.
@@ -99,6 +123,20 @@ func (v *validator) isValidSubject(s string) error {
 // a successfull validation.
 func ValidateMessage(s *parser.CommitMessage) (string, error) {
 	v := NewValidator()
+
+	// Validate the commit message length (should not be more than 50 characters long)
+	var fullMessage string
+	if s.Scope != "" {
+		fullMessage = fmt.Sprintf("%s(%s): %s", s.Type, s.Scope, s.Description)
+	} else {
+		fullMessage = fmt.Sprintf("%s: %s", s.Type, s.Description)
+	}
+	fullMessage = strings.TrimSpace(fullMessage)
+
+	// Validate the full commit message length
+	if err := v.isValidLength(fullMessage); err != nil {
+		return "", err
+	}
 
 	// Validate the commit message type and return an appropriate message else an error
 	if err := v.isValidType(s.Type); err != nil {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -139,3 +139,58 @@ func TestValidateMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidLength(t *testing.T) {
+	v := NewValidator()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:    "valid length message under 50 characters",
+			input:   "feat(auth): add OAuth2 login flow",
+			wantErr: false,
+		},
+		{
+			name:    "valid length message exactly 50 characters",
+			input:   "fix(parser): handle nil pointers in error check",
+			wantErr: false,
+		},
+		{
+			name: "invalid length message over 50 characters",
+			input: "feat(user): this message definitely exceeds the fifty " +
+				"character limit",
+			wantErr:     true,
+			expectedErr: "commit message is 69 long but expected length should be 50",
+		},
+		{
+			name:    "empty message is valid",
+			input:   "",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.isValidLength(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				} else if err.Error() != tt.expectedErr {
+					t.Errorf(
+						"unexpected error message:\ngot:  %s\nwant: %s",
+						err.Error(),
+						tt.expectedErr,
+					)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR enhances the validator to check for valid length of the commit message. A failed validation, meaning a commit message with length greater than 50 characters will throw an error message. On validation failure, the program exits with a non-zero status code.

Closes #24 