### PR TITLE
feat(parser): update the parser to match "breaking changes"

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -23,6 +23,7 @@ type Parser interface {
 //   - Footer: The optional metadata such as a breaking changes or issues closed info.
 type CommitMessage struct {
 	Type, Scope, Description, Body, Footer string
+	IsBreaking                             bool
 }
 
 // The `parserImpl` is the internal implementation of the `Parser` interface.
@@ -50,7 +51,7 @@ func (p *parserImpl) Parse(message string) (*CommitMessage, error) {
 		return nil, errors.New("no commit message was passed")
 	}
 
-	headerPattern := regexp.MustCompile(`^(\w+)(?:\(([^)]+)\))?:\s*(.+)$`)
+	headerPattern := regexp.MustCompile(`^([a-zA-Z]+)(?:\(([^)]+)\))?(!)?:\s*(.+)$`)
 	matches := headerPattern.FindStringSubmatch(lines[0])
 	if matches == nil {
 		return nil, errors.New("failed to parse the commit header")
@@ -59,7 +60,8 @@ func (p *parserImpl) Parse(message string) (*CommitMessage, error) {
 	parsed := &CommitMessage{
 		Type:        matches[1],
 		Scope:       matches[2],
-		Description: matches[3],
+		IsBreaking:  matches[3] == "!",
+		Description: matches[4],
 	}
 
 	if len(lines) > 1 {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -31,7 +31,8 @@ This fixes a bug where the parser crashed when encountering empty lines.`,
 				Type:        "fix",
 				Scope:       "parser",
 				Description: "handle empty lines",
-				Body:        "This fixes a bug where the parser crashed when encountering empty lines.",
+				Body: "This fixes a bug where the parser crashed when " +
+					"encountering empty lines.",
 			},
 		},
 		{
@@ -45,8 +46,9 @@ BREAKING CHANGE: config CLI flags have changed.`,
 				Type:        "feat",
 				Scope:       "core",
 				Description: "add config file support",
-				Body:        "Allows reading from config.json and merging it with CLI args.",
-				Footer:      "BREAKING CHANGE: config CLI flags have changed.",
+				Body: "Allows reading from config.json and merging it with " +
+					"CLI args.",
+				Footer: "BREAKING CHANGE: config CLI flags have changed.",
 			},
 		},
 		{
@@ -94,6 +96,45 @@ func TestParse_InvalidMessages(t *testing.T) {
 			_, err := parser.Parse(tt.input)
 			if err == nil {
 				t.Errorf("expected an error for input: %q", tt.input)
+			}
+		})
+	}
+}
+
+func TestParse_BreakingChanges(t *testing.T) {
+	parser := NewParser()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantType string
+		wantBang bool
+	}{
+		{
+			name:     "Breaking change with exclamation",
+			input:    "feat!: send an email to the customer when a product is shipped",
+			wantType: "feat",
+			wantBang: true,
+		},
+		{
+			name:     "Breaking change with scope and exclamation",
+			input:    "chore(parser)!: major rewrite for performance",
+			wantType: "chore",
+			wantBang: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Type != tt.wantType {
+				t.Errorf("got type = %q; want %q", result.Type, tt.wantType)
+			}
+			if result.IsBreaking != tt.wantBang {
+				t.Errorf("got breaking = %v; want %v", result.IsBreaking, tt.wantBang)
 			}
 		})
 	}


### PR DESCRIPTION
This PR includes some changes to the parser so that it can match for an optional `!` mark in the commit message. The exclamation mark signifies a breaking change introduced in a particular commit message. In addition to the parsing logic, the PR also includes relevant tests for the logic t be tested on.

Closes #48.