### PR TITLE
chore(pre-commit): update the Pre-Commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/Weburz/crisp
-    rev: v0.1.5
+    rev: v1.0.0
     hooks:
       - id: crisp
         name: lint git-commit messages
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.0.2
+    rev: v2.2.2
     hooks:
       - id: golangci-lint
         name: lint Go source code


### PR DESCRIPTION
This PR updates the Pre-Commit hooks (including Crisp).