### PR TITLE
chore(docs): update site config for custom domain & fix broken links

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,8 +6,7 @@ import { getCache } from "@beoe/cache";
 const cache = getCache();
 
 export default defineConfig({
-  site: "https://weburz.github.io/crisp",
-  base: "crisp",
+  site: "https://crisp.weburz.com",
   integrations: [
     starlight({
       title: "Crisp",
@@ -61,7 +60,7 @@ export default defineConfig({
         {
           strategy: "file",
           fsPath: "public/beoe",
-          webPath: "/crisp/beoe",
+          webPath: "/beoe",
           cache,
         },
       ],

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -10,8 +10,8 @@ import { Schema } from "astro-seo-schema";
     "@type": "SoftwareApplication",
     name: "Crisp",
     description: "A linter for your Git commit messages.",
-    documentation: "https://tech.weburz.com/crisp/",
-    termsOfService: "https://weburz.com/terms-of-services",
+    documentation: "https://crisp.weburz.com/",
+    termsOfService: "https://weburz.com/terms-and-conditions",
     provider: {
       "@type": "Organization",
       name: "Weburz Ltd",

--- a/docs/src/content/docs/dev-guide/contribute.md
+++ b/docs/src/content/docs/dev-guide/contribute.md
@@ -8,7 +8,7 @@ sidebar:
   order: 2
 ---
 
-[Crisp](https://tech.weburz.com/crisp) is a Free and Open Source Software
+[Crisp](https://crisp.weburz.com) is a Free and Open Source Software
 (FOSS), hence we welcome contributions from everyone and aim to make this
 project a positive and collaborative space for everyone involved with it.
 

--- a/docs/src/content/docs/dev-guide/development-process.md
+++ b/docs/src/content/docs/dev-guide/development-process.md
@@ -10,7 +10,7 @@ sidebar:
 ---
 
 This document outlines the development process for
-[Crisp](https://tech.weburz.com/crisp), a command-line interface (CLI) tool
+[Crisp](https://crisp.weburz.com), a command-line interface (CLI) tool
 built with the [Go](https://go.dev) programming language. This section of the
 documentation provides a detailed process for developing Crisp. Adhering to this
 process ensures smooth collaboration and code quality.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
   #   file: ../../assets/houston.webp
   actions:
     - text: Usage Guide
-      link: /crisp/usage-guide
+      link: /usage-guide
       icon: right-arrow
     - text: Contribute on GitHub
       link: https://github.com/Weburz/crisp
@@ -38,7 +38,7 @@ import AboutWeburz from "../../components/about-weburz.astro";
     Crisp provides first-class support for [Git
     Hooks](https://git-scm.com/docs/githooks) with the help of the
     [Pre-Commit](https://pre-commit.com) framework. Check out the "[Getting
-    Started](/crisp/usage-guide#pre-commit-hook)" section of the documentation
+    Started](/usage-guide#pre-commit-hook)" section of the documentation
     for more instructions.
   </Card>
   <Card title="Easy to Configure" icon="seti:config">


### PR DESCRIPTION
### Update site config for custom domain

This is one of the tasks in #56 Update the Docs issue that needed to be fixed before moving on to add the Umami Analytics.

**Changes:**
- Updated `site` URL to `crisp.weburz.com`
- Removed `base` path configuration for custom domain routing
- Fixed Mermaid diagram web path from `/crisp/beoe` to `/beoe`

The domain will be moved to `crisp.weburz.com` and this PR prepares the project for that.