### PR TITLE
fix(docs): fix grammar & add parser instructions

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,6 +33,8 @@ tasks:
     cmds:
       - task: install
       - task: docs:setup
+      - pre-commit install --install-hooks
+      - pre-commit install --hook-type commit-msg
 
   build:
     desc: Build the binary for the current system architecture.

--- a/docs/src/content/docs/architecture/index.md
+++ b/docs/src/content/docs/architecture/index.md
@@ -2,8 +2,7 @@
 title: Architectural Overview
 ---
 
-The internal logic that powers Crisp are divided into three distinct individual
-parts:
+The internal logic that powers Crisp is divided into three distinct parts:
 
 1. The **reader** which is responsible for reading the Git commit message either
    from STDIN (piped in) or from the `$GIT_DIR/COMMIT_EDITMSG` file (see the
@@ -15,9 +14,9 @@ parts:
 3. The `validator` which is responsible for running some validation logic on the
    parsed data.
 
-Under the hood, all three of the aforementioned components work in tandem to
-lint your Git commit messages. The following diagram will provide a better
-understanding of the underlying logic of the software.
+Under the hood, all three components work in tandem to lint your Git commit
+messages. The following diagram provides a better understanding of the
+underlying logic.
 
 ```mermaid
 sequenceDiagram
@@ -70,7 +69,7 @@ following means:
 3. Read the `$GIT_DIR/COMMIT_EDITMSG` file.
 
 In other words, Crisp can read a commit message if it is directly passed to it
-as a argument of the `message` command as shown below;
+as an argument of the `message` command as shown below:
 
 ```console
 crisp message "$(git show --no-patch --format=%B)"
@@ -81,7 +80,7 @@ for quickly validating a single message. The recommended approach to lint a
 commit message is to pass the data to Crisp through `STDIN`. Crisp will read
 from `STDIN` if the `--stdin` flag is passed to the `message` command.
 
-So, piping a commit message to Crisp is possible like this;
+Piping a commit message to Crisp is possible like this:
 
 ```console
 git show --no-patch --format=%B | crisp message --stdin
@@ -92,8 +91,8 @@ reading from the
 [`$GIT_DIR/COMMIT_EDITMSG`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt-codeGITDIRCOMMITEDITMSGcode)
 file.
 
-The diagram below will provide a better understanding of how the reader works
-behind-the-scenes.
+The diagram below provides a better understanding of how the reader works
+behind the scenes.
 
 ```mermaid
 stateDiagram-v2
@@ -124,22 +123,71 @@ stateDiagram-v2
 
 ## Parser
 
-<!--prettier-ignore-start-->
-:::caution
-The parser is still heavily a work-in-progress (WIP) and hence information regarding it
-is temporarily unavailable.
-:::
-<!--prettier-ignore-end-->
-
 The parser is responsible for receiving content from the reader and parsing it
-into the following components;
+into the following components:
 
-1. **Header**
-2. **Body**
-3. **Footer**
+1. **Header** — the first line of the commit message, containing the type,
+   optional scope, and description.
+2. **Body** — optional free-form text separated from the header by a blank line.
+3. **Footers** — optional key-value pairs (e.g. `BREAKING CHANGE`, `Closes`,
+   `Fixes`, `Refs`) appearing after the body.
 
-Upon successful parsing operation, the logic generates and returns a Go struct
-for further processing and data validation.
+Upon a successful parse, the logic returns a `CommitMessage` struct for further
+processing and validation:
+
+```go
+type CommitMessage struct {
+    Type        string
+    Scope       string
+    Description string
+    Body        string
+    Footers     map[string]string
+}
+```
+
+### Header parsing
+
+The header is parsed using a regular expression that expects the following
+format:
+
+```
+<TYPE>(<SCOPE>): <DESCRIPTION>
+```
+
+The scope is optional. If the header does not match this format, an error is
+returned immediately with a reference to the Conventional Commits specification.
+
+### Body and footer parsing
+
+Lines after the header are processed sequentially. The parser tracks whether it
+is inside the footer section using an internal flag. A line is treated as a
+footer if it matches a recognised key (`BREAKING CHANGE`, `Closes`, `Fixes`, or
+`Refs`) followed by a colon and a value. Once a footer line is detected, all
+subsequent lines are treated as footers. Body lines are accumulated until the
+footer section begins.
+
+The diagram below illustrates the full parsing flow:
+
+```mermaid
+flowchart TD
+    A[Raw commit message string] --> B[Split into lines]
+    B --> C{First line empty?}
+    C -- Yes --> D[Return error: no commit message]
+    C -- No --> E[Parse header with regex]
+    E --> F{Header matches format?}
+    F -- No --> G[Return error: invalid format]
+    F -- Yes --> H[Extract Type, Scope, Description]
+    H --> I[Process remaining lines]
+    I --> J{Line is a known footer?}
+    J -- Yes --> K[Add to footers map\nSet inFooter = true]
+    J -- No --> L{inFooter = true?}
+    L -- Yes --> M[Discard line]
+    L -- No --> N[Append to body]
+    K --> I
+    M --> I
+    N --> I
+    I --> O[Return CommitMessage struct]
+```
 
 ## Validator
 

--- a/docs/src/content/docs/dev-guide/contribute.md
+++ b/docs/src/content/docs/dev-guide/contribute.md
@@ -95,7 +95,7 @@ Please adhere to the following guidelines:
   indentation).
 - **Naming conventions**: Use descriptive names for variables, functions, and
   classes.
-- **Documentation**: Ensure that your code is well-documented. Use docstrings or
+- **Documentation**: Ensure your code is well-documented. Use docstrings or
   comments to explain complex logic.
 - **Commit messages**: Follow the
   [Conventional Commits](#commit-message-conventions) specifications for writing

--- a/docs/src/content/docs/dev-guide/development-process.md
+++ b/docs/src/content/docs/dev-guide/development-process.md
@@ -18,8 +18,8 @@ process ensures smooth collaboration and code quality.
 Crisp is a linter for enforcing a uniform standard for writing
 [Git](https://git-scm.com) commit messages. The goal of this project is to
 provide an easy-to-use, efficient tool for linting Git commit messages in
-accordance to the [Conventional Commits](https://www.conventionalcommits.org)
-specifications. It is written in Go for its simplicity, performance, and ease of
+accordance with the [Conventional Commits](https://www.conventionalcommits.org)
+specification. It is written in Go for its simplicity, performance, and ease of
 use in building command-line tools.
 
 ## Setting Up the Development Environment
@@ -73,8 +73,7 @@ To maintain code consistency across the project, please adhere to the following
 guidelines:
 
 - **File structure**: Use a logical file structure to organize the project
-  (e.g., `cmd` for CLI commands, `pkg` for core logic, `internal` for internal
-  packages).
+  (e.g., `cmd` for CLI commands, `internal` for internal packages).
 - **Go naming conventions**: Follow the official Go naming conventions. For
   example, use camelCase for variable names and PascalCase for function names
   and types.

--- a/docs/src/content/docs/dev-guide/specifications.md
+++ b/docs/src/content/docs/dev-guide/specifications.md
@@ -6,12 +6,12 @@ sidebar:
 
 This section of the documentations contains the "Software Requirements
 Specifications (SRS)" for Crisp. All feature enhancements and related
-development on the project will be based on the criterias listed here on this
+development on the project will be based on the criteria listed in this
 document. Any other feature request or behaviour of the tool which can be
-considered out-of-scope of this document will not be worked upon. In case, a
+considered out-of-scope of this document will not be worked upon. If a
 functionality or behaviour has been heavily requested by community members, the
 document will first have to be updated accordingly before development on the
-functionality can start taking shape.
+functionality can begin.
 
 ## Purpose
 
@@ -24,9 +24,9 @@ it simply, Crisp is a linter for Git commit messages!
 ## Scope
 
 The core functionality of Crisp should be to enforce the rules and guidelines
-for authoring Git commit messages in accordance to the Conventional Commits
-v1.0.0 specifications. Additional functionalities can be added to the project
-but they should not deviate from the core functionality.
+for authoring Git commit messages in accordance with the Conventional Commits
+v1.0.0 specification. Additional functionality can be added to the project
+but it should not deviate from the core functionality.
 
 On top of the core functionality mentioned above, the following functionalities
 (and their similarities) should be outright considered out of scope for the

--- a/docs/src/content/docs/usage-guide/index.mdx
+++ b/docs/src/content/docs/usage-guide/index.mdx
@@ -4,9 +4,8 @@ description: Get started with using Crisp to lint your commit messages.
 ---
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Getting started with using Crisp is very straight-forward and not very involved
-in any way! To get started with using Crisp for your requirements, you have the
-following options:
+Getting started with Crisp is straightforward. To get started for your
+requirements, you have the following options:
 
 1. Use as a [Pre-Commit](https://pre-commit.com) hook (**RECOMMENDED**).
 2. Use as a standalone tool, either built from source or downloaded using a
@@ -19,8 +18,8 @@ ways to get started with using Crisp.
 
 ## Pre-Commit Hook
 
-The easiest and most straight-forward approach for using Crisp is to utilise it
-as a Pre-Commit hook. So, the following steps will help you with the process:
+The easiest and most straightforward approach is to use Crisp as a Pre-Commit
+hook. The following steps will help you with the process:
 
 1. Ensure Pre-Commit is locally installed and accessible (following the
    [official installation guidelines](https://pre-commit.com#installation)).
@@ -30,7 +29,7 @@ as a Pre-Commit hook. So, the following steps will help you with the process:
    ```yaml
    repos:
      - repo: https://github.com/Weburz/crisp
-       rev: "v0.1.5"
+       rev: "v1.0.0"
        hooks:
          - id: crisp
    ```
@@ -111,8 +110,8 @@ if you are facing issues with it.
 ## Build From Source
 
 Crisp can also be built from source and used accordingly. The added benefit of
-this approach is you will get to the test out the absolute latest
-functionalities of the tool before they are stabilised and shipped. Follow these
+this approach is that you will get to test out the absolute latest
+functionality of the tool before it is stabilised and shipped. Follow these
 steps if you are interested in building Crisp from source code:
 
 1. Clone the source code's remote repository from our GitHub organisation by

--- a/docs/src/content/docs/usage-guide/reference.md
+++ b/docs/src/content/docs/usage-guide/reference.md
@@ -3,14 +3,13 @@ title: Command-Line Interface (CLI) Reference
 description: The CLI reference of Crisp
 ---
 
-Crisp as a CLI tool is rather quite simple and straight-forward to use. It has
-been kept that way intentionally and its simplicity is one of the core design
-principle of the tool. Hence this section of the documentation provides a
-detailed reference of the very list of commands available for `crisp`.
+Crisp as a CLI tool is intentionally simple and straightforward to use. Its
+simplicity is one of the core design principles of the tool. This section of
+the documentation provides a detailed reference of the commands available for
+`crisp`.
 
-While this section of the documentation exists for an easier reference browsing
-over your preferred web browser, it is highly recommended you use `help` command
-for quick reference instead.
+While this section exists for convenient reference in your browser, it is
+recommended to use the `help` command for quick reference instead.
 
 ## Reference
 
@@ -31,7 +30,7 @@ purposes they fulfill.
 | `bash`       | Generate the autocompletion script for Bash.       |
 | `fish`       | Generate the autocompletion script for Fish.       |
 | `powershell` | Generate the autocompletion script for PowerShell. |
-| `zsh`        | Generate the autocompletion script Zsh.            |
+| `zsh`        | Generate the autocompletion script for Zsh.        |
 
 TODO: Add some examples of its usage.
 


### PR DESCRIPTION
 Complete the WIP parser section in the architecture overview with a full description of the parsing flow, CommitMessage struct, and a Mermaid diagram. Also fix grammar and wording across multiple docs files, update the pre-commit hook revision to v1.0.0, and auto-install hooks in the setup task.